### PR TITLE
fix: source nvm in deploy workflow so SSH uses correct Node version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
             if [ "${{ github.ref_name }}" = "production" ]; then
               ~/kido-worker-hours/deploy.sh
             else


### PR DESCRIPTION
Non-interactive SSH shells don't load nvm, falling back to system Node v19 instead of v22. Source nvm.sh before running deploy scripts.